### PR TITLE
support executing `enqueue_job!` without `worker_class_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And start Embed Worker Manager and enqueue a job.
 
 ```ruby
 manager = Rasteira::EmbedWorker::Manager.run
-manager.enqueue_job!('HelloWorker', 'example/hello_worker.rb', 'serihiro')
+manager.enqueue_job!('HelloWorker', worker_file_path: 'example/hello_worker.rb', args: ['serihiro', 'hogetarou'])
 ```
 
 ## Development

--- a/example/hello_worker.rb
+++ b/example/hello_worker.rb
@@ -1,10 +1,16 @@
 # To test with bin/console, execute like this:
 #
 # 2.4.0 :001 > m = Rasteira::EmbedWorker::Manager.run
-# 2.4.0 :002 > m.enqueue_job!('HelloWorker', 'example/hello_worker.rb', 'serihiro')
+# 2.4.0 :002 > m.enqueue_job!('HelloWorker', worker_file_path: 'example/hello_worker.rb', args: ['serihiro', 'hogetarou'])
+#
+# OR
+#
+# 2.4.0 :001 > m = Rasteira::EmbedWorker::Manager.run
+# 2.4.0 :002 > require './example/hello_worker.rb'
+# 2.4.0 :003 > m.enqueue_job!('HelloWorker', args: ['serihiro', 'hogetarou'])
 #
 class HelloWorker
-  def perform(name)
-    puts "Hello, #{name}"
+  def perform(name1, name2)
+    puts "Hello, #{name1}, #{name2}"
   end
 end

--- a/lib/rasteira/core/job.rb
+++ b/lib/rasteira/core/job.rb
@@ -2,23 +2,26 @@ module Rasteira
   module Core
     class Job
       attr_reader :worker_name, :worker_file_path, :args, :status
-      
+
       STATUSES = {
         ready: 0,
         in_process: 1,
         finished: 2,
         failed: 3
       }.freeze
-    
-      def initialize(worker_name, worker_file_path, *args)
-        @worker_file_path = File.expand_path(worker_file_path, Dir.pwd)
-        unless File.exists?(@worker_file_path)
-          raise ArgumentError.new("#{@worker_file_path} could not be found")
+
+      def initialize(worker_name, options = {})
+        if !options[:worker_file_path].nil?
+          @worker_file_path = File.expand_path(options[:worker_file_path], options[:current_directory] || Dir.pwd)
+          unless File.exists?(@worker_file_path)
+            raise ArgumentError.new("#{@worker_file_path} could not be found")
+          end
+
+          require(@worker_file_path)
         end
-      
-        require(@worker_file_path)
+
         @worker_name = worker_name
-        @args = args
+        @args = options[:args]
         @status = STATUSES[:ready]
       end
     

--- a/lib/rasteira/version.rb
+++ b/lib/rasteira/version.rb
@@ -1,3 +1,3 @@
 module Rasteira
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/rasteira.gemspec
+++ b/rasteira.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'yard'
 end

--- a/spec/core/job_spec.rb
+++ b/spec/core/job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Rasteira::Core::Job do
   end
 
   describe '.new' do
-    subject { Rasteira::Core::Job.new(worker_name, worker_file_path, args) }
+    subject { Rasteira::Core::Job.new(worker_name, worker_file_path: worker_file_path, args: args) }
     
     context 'with existing worker_file_path' do
       let(:worker_name) { 'HelloWorker' }
@@ -46,7 +46,7 @@ RSpec.describe Rasteira::Core::Job do
   end
 
   describe '#start!' do
-    subject { Rasteira::Core::Job.new(worker_name, worker_file_path, *args).start! }
+    subject { Rasteira::Core::Job.new(worker_name, worker_file_path: worker_file_path, args: args).start! }
     let(:worker_name) { 'HelloWorker' }
     let(:worker_file_path) { @hello_worker_file.path }
     let(:args) { ['tarou', 'jirou'] }
@@ -57,7 +57,7 @@ RSpec.describe Rasteira::Core::Job do
   end
   
   describe '#worker' do
-    subject { Rasteira::Core::Job.new(worker_name, worker_file_path, *args).worker }
+    subject { Rasteira::Core::Job.new(worker_name, worker_file_path: worker_file_path, args: args).worker }
     let(:worker_name) { 'HelloWorker' }
     let(:worker_file_path) { @hello_worker_file.path }
     let(:args) { ['tarou', 'jirou'] }

--- a/spec/embed_worker/manager_spec.rb
+++ b/spec/embed_worker/manager_spec.rb
@@ -38,15 +38,27 @@ RSpec.describe Rasteira::EmbedWorker::Manager do
     before :each do
       # mock
       class Rasteira::Core::Job
-        def initialize(_worker_name, _wrker_file_path, *_args)
+        def initialize(_worker_name, _options = {})
         end
       end
     end
     let(:manager) { Rasteira::EmbedWorker::Manager.new }
-    subject { manager.enqueue_job!('worker_name', 'worker_path') }
     
-    it 'increase @job_pool count' do
-      expect { subject }.to change { manager.job_pool.size }.from(0).to(1)
+    context 'with worker_path' do
+      subject { manager.enqueue_job!('worker_name', worker_path: 'worker_path') }
+  
+      it 'increase @job_pool count' do
+        expect { subject }.to change { manager.job_pool.size }.from(0).to(1)
+      end
+    end
+    
+    
+    context 'without worker_path' do
+      subject { manager.enqueue_job!('worker_name') }
+  
+      it 'increase @job_pool count' do
+        expect { subject }.to change { manager.job_pool.size }.from(0).to(1)
+      end
     end
   end
   


### PR DESCRIPTION
# What will this PR change?
- optionize `worker_class_path` so that user can execute `enqueue_job!` without specifying `worker_class_path`.
- This change is for supporting already required Worker Class.