### PR TITLE
Support array argument

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+# What is this issue about ?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+# What will this PR change ?

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,7 +41,7 @@ Layout/AlignHash:
 Layout/AlignParameters:
   Enabled: false
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:

--- a/lib/rasteira/core/job.rb
+++ b/lib/rasteira/core/job.rb
@@ -39,7 +39,7 @@ module Rasteira
       def start!
         @status = STATUSES[:in_process]
         begin
-          worker.perform(*@args)
+          worker.method(:perform).arity > 1 ? worker.perform(*@args) : worker.perform(@args)
           @status = STATUSES[:finished]
         rescue => e
           @status = STATUSES[:failed]

--- a/lib/rasteira/version.rb
+++ b/lib/rasteira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rasteira
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/rasteira.gemspec
+++ b/rasteira.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.52.1'
   spec.add_development_dependency 'yard'
 end

--- a/spec/core/job_spec.rb
+++ b/spec/core/job_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe Rasteira::Core::Job do
     it 'does not raise_error' do
       expect { subject }.not_to raise_error
     end
+
+    context 'with single array arg' do
+      before :each do
+        @hello_worker_file2 = Tempfile.new(%w(worker2 .rb))
+
+        class_string = <<-'EOS'
+          class HelloWorker2
+            def perform(names)
+              "Hello, #{names[0]} and #{names[1]}"
+            end
+          end
+        EOS
+
+        @hello_worker_file2.print(class_string)
+        @hello_worker_file2.open
+      end
+
+      let(:worker_class) { 'HelloWorker2' }
+      let(:worker_file_path) { @hello_worker_file2.path }
+      let(:args) { %w(tarou jirou) }
+
+      it 'does not raise_error' do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 
   describe '#worker' do


### PR DESCRIPTION
# What will this PR change ?
Support single array arg, like this:

```ruby
class HelloWorker2
  def perform(names)
    "Hello, #{names[0]} and #{names[1]}"
  end
end
```